### PR TITLE
Fix `--as-needed` unknown argument error from wasm-ld

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,8 +180,10 @@ unset ( FLUID_LIBS CACHE )
 # Options for the GNU C compiler only
 if ( CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "Intel" )
   if ( NOT APPLE AND NOT OS2 )
-    set ( CMAKE_EXE_LINKER_FLAGS
-          "${CMAKE_EXE_LINKER_FLAGS} -Wl,--as-needed" )
+    if ( NOT EMSCRIPTEN_SUPPORT )
+      set ( CMAKE_EXE_LINKER_FLAGS
+            "${CMAKE_EXE_LINKER_FLAGS} -Wl,--as-needed" )
+    endif ( NOT EMSCRIPTEN_SUPPORT )
     set ( CMAKE_SHARED_LINKER_FLAGS
           "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined" )
   endif ( NOT APPLE AND NOT OS2 )


### PR DESCRIPTION
(Re-open of #2 to fix diff)

Per #1, this fork does not compile with latest emsdk due to the following error:

```sh
[ 97%] Built target libfluidsynth-OBJ
Scanning dependencies of target libfluidsynth
[100%] Linking C executable libfluidsynth-2.0.2.js
wasm-ld: error: unknown argument: --as-needed
emcc: error: '/home/colab/workspace/emsdk/upstream/bin/wasm-ld @/tmp/emscripten_o2vhj64x.rsp' failed (1)
src/CMakeFiles/libfluidsynth.dir/build.make:142: recipe for target 'src/libfluidsynth-2.0.2.js' failed
make[2]: *** [src/libfluidsynth-2.0.2.js] Error 1
CMakeFiles/Makefile2:156: recipe for target 'src/CMakeFiles/libfluidsynth.dir/all' failed
make[1]: *** [src/CMakeFiles/libfluidsynth.dir/all] Error 2
Makefile:151: recipe for target 'all' failed
make: *** [all] Error 2
```

The argument is described according to this [Gentoo Wiki page](https://wiki.gentoo.org/wiki/Project:Quality_Assurance/As-needed#:~:text=The%20%2D%2Das%2Dneeded%20flag,final%20executable%20or%20another%20library.):

> The --as-needed flag is passed to the GNU linker (GNU ld ). The flag tells the linker to link in the produced binary only the libraries containing symbols actually used by the binary itself. This binary can be either a final executable or another library.

It does not appear essential for building, so I remove the flag for emscripten and it builds successfully. It produces a 634kB JS file.