### PR TITLE
Changes to load fluidsynth-emscriptem as an AudioWorklet processor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -708,7 +708,7 @@ else (NOT EMSCRIPTEN_SUPPORT)
     if ( NOT enable-separate-wasm )
         SET( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s SINGLE_FILE=1" )
     endif ( NOT enable-separate-wasm )
-    SET( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --pre-js ${CMAKE_SOURCE_DIR}/emscripten/src/pre.js -s ENVIRONMENT=web -s INITIAL_MEMORY=67108864 -s ALLOW_MEMORY_GROWTH=1 -s ALLOW_TABLE_GROWTH=1 -s EXPORTED_FUNCTIONS='[${EMSCRIPTEN_EXPORTS_OPTIONS}]' -s 'EXTRA_EXPORTED_RUNTIME_METHODS=[\"ccall\", \"cwrap\", \"FS\"]'" )
+    SET( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --pre-js ${CMAKE_SOURCE_DIR}/emscripten/src/pre.js -s ENVIRONMENT=web -s INITIAL_MEMORY=67108864 -s ALLOW_MEMORY_GROWTH=1 -s ALLOW_TABLE_GROWTH=1 -s EXPORTED_FUNCTIONS='[${EMSCRIPTEN_EXPORTS_OPTIONS}]' -s 'EXTRA_EXPORTED_RUNTIME_METHODS=[\"ccall\", \"cwrap\", \"FS\",\"addFunction\",\"removeFunction\",\"MEMFS\",\"lengthBytesUTF8\",\"UTF8ArrayToString\",\"UTF8ToString\",\"stringToUTF8Array\",\"stringToUTF8\"]'" )
     SET( CMAKE_EXECUTABLE_SUFFIX ".js" )
 
     find_package ( PkgConfig REQUIRED )

--- a/emscripten/src/pre.js
+++ b/emscripten/src/pre.js
@@ -4,6 +4,37 @@ var document = typeof document !== 'undefined' ? document : {};
 var window = typeof window !== 'undefined' ? window : {};
 // expose wasm API to AudioWorklet
 if (typeof AudioWorkletGlobalScope !== 'undefined' && AudioWorkletGlobalScope) {
+    var atob = function (input) {
+        var keyStr = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+
+        var output = '';
+        var chr1, chr2, chr3;
+        var enc1, enc2, enc3, enc4;
+        var i = 0;
+        // remove all characters that are not A-Z, a-z, 0-9, +, /, or =
+        input = input.replace(/[^A-Za-z0-9\+\/\=]/g, '');
+        do {
+            enc1 = keyStr.indexOf(input.charAt(i++));
+            enc2 = keyStr.indexOf(input.charAt(i++));
+            enc3 = keyStr.indexOf(input.charAt(i++));
+            enc4 = keyStr.indexOf(input.charAt(i++));
+
+            chr1 = (enc1 << 2) | (enc2 >> 4);
+            chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
+            chr3 = ((enc3 & 3) << 6) | enc4;
+
+            output = output + String.fromCharCode(chr1);
+
+            if (enc3 !== 64) {
+                output = output + String.fromCharCode(chr2);
+            }
+            if (enc4 !== 64) {
+                output = output + String.fromCharCode(chr3);
+            }
+        } while (i < input.length);
+        return output;
+    };
+
     AudioWorkletGlobalScope.wasmModule = Module;
     AudioWorkletGlobalScope.wasmAddFunction = addFunction;
     AudioWorkletGlobalScope.wasmRemoveFunction = removeFunction;


### PR DESCRIPTION
After upgrading from fluidsynth-emscripten-2.2.1 to 2.3.0 I ran into problems trying to load the module.  There are also some changes here that I had previously made for 2.2.1.

    With these changes I am able to build and load fluidsynth as an AudioWorklet processor.

    From v2.2.1 also needed in v2.3.0
    - Added some additional EXPORTS to CMakelists.txt to fix runtime unresolveds: addFunction,removeFunction,MEMFS,lengthBytesUTF8,UTF8ArrayToString,UTF8ToString,stringToUTF8Array,stringToUTF8.

    Additional change for 2.3.0
    Failed to Base64 decode the WASM binary b/c atob() didn't exist.  Maybe it's not defined in the AudioWorklet scope?  I put back a polyfill that was in the 2.2.1 code built by an older emscriptem, added this to pre.js.

    Build tools:
    emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 3.1.43 (a6b8143cf3c1171db911750359456b15a8deece7)
    clang version 17.0.0 (https://github.com/llvm/llvm-project 71513a71cdf380efd6a44be6939e2cb979a62407)
    Target: wasm32-unknown-emscripten
    Thread model: posix

    Tested on Chrome Version 114.0.5735.133 (Official Build) (64-bit)

    Significant possibility that this is user error on my part, but I was not able to find another solution.